### PR TITLE
Adds netlify.toml to configure Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+base = "./"
+publish = "_site/"
+command = "jekyll build"
+
+[context.production]
+  command = "JEKYLL_ENV=production jekyll build"
+


### PR DESCRIPTION
Just realised that the default build command for `master`/production does not set the correct environment variable. Which lead to no analytics since 18th of April.