### PR TITLE
Fixes opacity setting of scroll indicator in Safari

### DIFF
--- a/_sass/scroll-indicator.scss
+++ b/_sass/scroll-indicator.scss
@@ -9,7 +9,7 @@
 .scroll-indicator {
   background: #FFF;
   height: $scroll-indicator-height;
-  opacity: 40%;
+  opacity: 0.4;
   width: 0%;
 }
 


### PR DESCRIPTION
In Safari the percentage doesn't seem to work as expected.